### PR TITLE
Better merge pull request #5 + pull request #7

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -100,9 +100,14 @@ channelThumbnailInput.addEventListener('change', (e) => {
 
 
 function findCard(title) {
+  // Select randomly a card between a range
+  let min = 1
+  let max = 12
+  let cardPositionIndex = Math.floor(Math.random() * (max - min + 1)) + min
   
-  let cardPositionIndex = 4;
-  let target = document.querySelectorAll('.ytd-rich-item-renderer')[cardPositionIndex]
+  // Target only ytd-rich-item-renderer element and not ytd-rich-item-renderer with id content
+  let cards = document.querySelectorAll('.ytd-rich-item-renderer:not(#content)')
+  let target = cards[cardPositionIndex]
   
   // Si le user n'est pas sur YT => message d'erreur
   if(typeof(target) === "undefined") {
@@ -112,18 +117,6 @@ function findCard(title) {
   
   
   chrome.storage.local.get("thumbnailProperties", (result) => {
-
-
-    // Select randomly a card between a range
-    let min = 1
-    let max = 12
-
-    // Target only ytd-rich-item-renderer element and not ytd-rich-item-renderer with id content
-    const cards = document.querySelectorAll('.ytd-rich-item-renderer:not(#content)')
-    const cardPositionIndex = Math.floor(Math.random() * (max - min + 1)) + min
-
-    const target = cards[cardPositionIndex]
-
     const thumbnail = target.querySelector('.yt-img-shadow')
     thumbnail.src = result.thumbnailProperties.thumbnail
 


### PR DESCRIPTION
Encore une PR désolé ^^
C'est juste pour améliorer le code suite aux merges #5 et #7 , on avait du code en double pas utile
J'ai simplement décalé l'objet de la thumbnail (récupéré aléatoirement grâce à #7 ) avant le contrôle qui lance le message d'erreur si on est pas sur YT
Je sais pas si git n'était pas censé crier au conflit de merge dans ce cas là, en tout cas ça reste intéressant de faire ça sur un petit projet

Quelques idées : 
- faudrait vraiment mettre à jour le manifest avec le titre/description de l'extension ^^
- suite à la thumbnail aléatoire, des fois c'est une thumbnail quasi en dehors de l'écran qui est prise, je pense qu'il faudrait automatiquement scroller sur la thumbnail en question pour qu'on s'assure qu'elle soit visible ; j'ai tenté de jouer avec du target.scrollIntoView dans findCard juste après le contrôle "typeof(target)" mais ça marche moyen
- en plus de ça, pourquoi pas donner un effet visuel sur la thumbnail qui vient de changer pour que ça soit plus visible (fade / clignoter / border temporaire ..)

Voilà voilà