### PR TITLE
Add support for Firefox (and other cool stuff)

### DIFF
--- a/content.js
+++ b/content.js
@@ -57,13 +57,16 @@ function hidePopup() {
 
 function findCard() {
     // Select a random a card in between a range
-    let cardPositionIndex = 1
+    let cardPositionIndex = 0
 
     const activeScreen = document.querySelector('[role="main"]')
     // Target only ytd-rich-item-renderer element and not ytd-rich-item-renderer with id content for the main page
-    let cards = activeScreen.querySelectorAll('.ytd-rich-item-renderer:not(#content)')
+    let cards = activeScreen.querySelectorAll('.ytd-rich-item-renderer:not(#content):not(ytd-display-ad-renderer)')
     if (cards.length === 0) {
         cards = activeScreen.getElementsByTagName('ytd-grid-video-renderer')
+    }
+    if (cards.length === 0) {
+        cards = activeScreen.getElementsByTagName('ytd-compact-video-renderer')
     }
 
     chrome.storage.local.get('thumbnailProperties', (result) => {
@@ -78,7 +81,10 @@ function findCard() {
         thumbnail.src = result.thumbnailProperties.thumbnail
 
         const title = target.querySelector('#video-title')
-        const channelName = target.querySelector('.ytd-channel-name a')
+        let channelName = target.querySelector('.ytd-channel-name a')
+        if (!channelName) {
+            channelName = target.querySelector('.ytd-channel-name')
+        }
 
         title.textContent = result.thumbnailProperties.title
         channelName.textContent = result.thumbnailProperties.channelName
@@ -97,7 +103,10 @@ function findCard() {
         }
 
         // Finally, set the channel's thumbnail in the preview
-        target.querySelector('#avatar-link img').src = channelThumbnailValue
+        let avatar = target.querySelector('#avatar-link img')
+        if (avatar) {
+            avatar.src = channelThumbnailValue
+        }
 
         hidePopup()
     })

--- a/manifest.json
+++ b/manifest.json
@@ -2,9 +2,9 @@
   "name": "PrevYou — YouTube Thumbnail Previewer",
   "description": "Preview your video thumbnail and title on YouTube home page or subscription feed.",
   "version": "1.1",
-  "manifest_version": 3,
-  "permissions": ["storage", "activeTab", "scripting"],
-  "action": {
+  "manifest_version": 2,
+  "permissions": ["storage", "activeTab", "tabs"],
+  "browser_action": {
     "default_popup": "popup-wrapper.html",
     "default_icon": {
       "16": "/images/logo16.png",
@@ -13,18 +13,8 @@
       "128": "/images/logo128.png"
     }
   },
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "css": ["content.css"],
-      "js": ["content.js"]
-    }
-  ],
   "web_accessible_resources": [
-    {
-      "resources": ["popup.html"],
-      "matches": ["<all_urls>"]
-    }
+    "popup.html"
   ],
   "icons": {
     "16": "/images/logo16.png",

--- a/popup-wrapper.html
+++ b/popup-wrapper.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="UTF-8">
 </head>
-<body>
+<body style="font-family: sans-serif; padding: 0 .5em; white-space: nowrap">
     <script src="popup-wrapper.js"></script>
+    <p id="extErrorMessage"></p>
 </body>
 </html>

--- a/popup-wrapper.js
+++ b/popup-wrapper.js
@@ -1,11 +1,25 @@
 chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
-    chrome.tabs.sendMessage(tabs[0].id, {
-        type: "popup"
-    },
-    (response) => {
-        if (response) {
-            //console.log(response);
+    if (tabs[0] === undefined || !tabs[0].url.startsWith('https://www.youtube.com/')) {
+        const errorMessageSpan = document.querySelector('#extErrorMessage')
+        errorMessageSpan.textContent = 'You need to be on YouTube!'
+        return
+    }
+
+    chrome.tabs.executeScript(tabs[0].id, {
+        // showPopup acutally toggles popup here
+        code: 'window.__PREVYOU_LOADED ? (showPopup(), true) : false'
+    }, res => {
+        if (!res[0]) {
+            chrome.tabs.executeScript(tabs[0].id, {
+                file: '/content.js'
+            })
+
+            chrome.tabs.insertCSS(tabs[0].id, {
+                file: '/content.css'
+            })
+
         }
+
+        window.close();
     });
-    window.close();
 });


### PR DESCRIPTION
Firefox is (to some extent) compatible with the Chrome extensions API, making it possible for PrevYou to be compatible both with Chrome and Firefox out of the box, with a couple of tweaks.

I (manually) tested that those changes work both in Chrome and Firefox. 👌 

### Set the manifest version to 2

Sadly it seems that Firefox doesn't yet support manifest version 3, but Chrome still supports version 2, so this works.

If Chrome was to drop support for version 2 before Firefox supports 3 (unlikely?), we could instead ship a ever so slightly different manifest to Firefox.

The only changes needed in the manifest are renaming `action` to `browser_action` and changing `web_accessible_resources` from an array of objects to an array of strings (`"matches": ["<all_urls>"]` is implicit).

### Trigger the script with `window.parent.postMessage` instead of `chrome.scripting.executeScript`

Firefox doesn't support the `chrome.scripting` API yet. It also doesn't allow content scripts to access the `chrome.tabs` API, only background scripts and the "real" extension popup can.

I assume that we don't use the "real" extension popup here because of the fact it auto hides when losing focus, making it impossible to do the file upload inside the popup, hence the in-page `<object>` popup.

We can use `window.parent.postMessage` from the `<object>` popup to communicate with the parent YouTube tab, where the content script uses `window.addEventListener('message')` to intercept it.

This required to move the `findCard` function from `popup.js` (where it was injected using `chrome.scripting.executeScript`) to `content.js`, which runs it when receiving the event from the `<object>` popup.

### Handle URL check/error in the "real" popup

Since we can't use the `chrome.tabs` API in the `<object>` popup, we can't do the `.startsWith('https://www.youtube.com/')` check here anymore.

Instead, this PR moves that check to the the "real" extension popup, and shows the error message there as well.

![Firefox](https://user-images.githubusercontent.com/3929133/124680259-02e4b080-de94-11eb-9abe-87e78661c6c9.png "Firefox")

![Chrome](https://user-images.githubusercontent.com/3929133/124680380-417a6b00-de94-11eb-87fc-8778b4058dd2.png "Chrome")

As a side effect, this seemingly small architectural change opened up the doors to what I think is a very cool performance improvement and I couldn't resist to include it in this PR even though it's not directly related to Firefox support. 

### Inject the script only when needed :sparkles:

Now that the domain check and error handling is done in the "real" extension popup, we don't need the content script to be present on every single tab anymore. We actually don't even need the script to be present on YouTube by default either, until we actually trigger the extension popup.

This means we can remove the content script altogether from the manifest file, and instead, inject it using `chrome.tabs.executeScript` and `chrome.tabs.insertCSS` from the popup wrapper.

This way, the extension adds no overhead to any website by default. Only when it is triggered on a YouTube URL, it will inject the JS and CSS to the page.

To support toggling the popup with the extension icon, and to avoid injecting the script and CSS multiple times in the same page, the popup wrapper first checks if the script was already loaded using a `window.__PREVYOU_LOADED` flag (checking `typeof showPopup !== 'undefined` would also work but I found the flag more explicit). If already loaded, it only runs `showPopup` to toggle the popup state.

### Support video page

I also made a quick update to `findCard` to make it work on the video page (injecting the thumb/title in the video suggestions on the right), which I find quite useful as well!

Since I moved the `findCard` function, the diff doesn't properly reflect those specific changes, so look at [the commit](https://github.com/bdebon/youtube-thumbnail-tester-chrome-extension/pull/37/commits/8ccfd54bb1b0a6a51df111f322c1c4ba0268639f) instead to see the detail. That's also why I included it in this PR, because making a separate PR targeting `main` would make both PRs conflict with each other.

---

Thanks for the cool extension (and videos). Cheers!