### PR TITLE
Run eslint --fix on all JS files

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,5 +1,5 @@
 var overlay = null,
-    frame = null;
+    frame = null
 
 window.__PREVYOU_LOADED = true
 
@@ -11,48 +11,48 @@ window.addEventListener('message', e => {
 })
 
 // Event send by the extension popup
-chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-    if (request.type == "popup") {
+chrome.runtime.onMessage.addListener(request => {
+    if (request.type == 'popup') {
         //console.log(request);
-        showPopup();
+        showPopup()
     } else if (request.type === 'close_popup') {
-        hidePopup();
+        hidePopup()
     }
-    return true;
-});
+    return true
+})
 
 function showPopup() {
-    if (document.querySelector(".py-popup-overlay")) {
-        hidePopup();
-        return false;
+    if (document.querySelector('.py-popup-overlay')) {
+        hidePopup()
+        return false
     }
 
-    overlay = document.createElement('div');
-    frame = document.createElement('object');
+    overlay = document.createElement('div')
+    frame = document.createElement('object')
 
-    overlay.className = "py-popup-overlay";
-    frame.className = "py-popup-container";
-    frame.setAttribute("scrolling", "no");
-    frame.setAttribute("frameborder", "0");
+    overlay.className = 'py-popup-overlay'
+    frame.className = 'py-popup-container'
+    frame.setAttribute('scrolling', 'no')
+    frame.setAttribute('frameborder', '0')
 
     // file need to be added in manifest web_accessible_resources
-    frame.data = chrome.runtime.getURL("popup.html");
-    overlay.appendChild(frame);
-    document.body.appendChild(overlay);
+    frame.data = chrome.runtime.getURL('popup.html')
+    overlay.appendChild(frame)
+    document.body.appendChild(overlay)
 
-    overlay.addEventListener("click", hidePopup);
+    overlay.addEventListener('click', hidePopup)
 }
 
 function hidePopup() {
     // Remove EventListener
-    overlay.removeEventListener("click", hidePopup);
+    overlay.removeEventListener('click', hidePopup)
 
     // Remove the elements:
-    document.querySelector(".py-popup-overlay").remove();
+    document.querySelector('.py-popup-overlay').remove()
 
     // Clean up references:
-    overlay = null;
-    frame = null;
+    overlay = null
+    frame = null
 }
 
 function findCard() {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "youtube-thumbnail-tester-chrome-extension",
   "main": "popup.js",
   "scripts": {
-    "lint": "./node_modules/.bin/eslint popup.js --fix",
+    "lint": "./node_modules/.bin/eslint . --fix",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/popup-wrapper.js
+++ b/popup-wrapper.js
@@ -20,6 +20,6 @@ chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
 
         }
 
-        window.close();
-    });
-});
+        window.close()
+    })
+})


### PR DESCRIPTION
When working on my last PR for Firefox support I noticed only `popup.js` was linted, and the style in `content.js` wasn't consistent so I couldn't lint my code there.

I didn't include this change in the previous PR because it would have messed up the diff, so here's a separate PR that replaces `eslint popup.js --fix` by `eslint . --fix` to apply to all JS files, and committed the changes. The only manual change I had to make was to remove the unused `sender` and `sendResponse` parameters to the `onMessage.addListener` callback.

---

Quick unrelated side note while I'm there, I see in [things to improve](https://github.com/bdebon/youtube-thumbnail-tester-chrome-extension#things-to-improve) in the readme that "drag and drop thumbnail should work" is not ticked, but this feature was working fine for me so maybe it's actually done? I'll let you confirm that :P