### PR TITLE
fix: update selector for thumbnail and avatar

### DIFF
--- a/content.js
+++ b/content.js
@@ -77,7 +77,7 @@ function findCard() {
             cardPositionIndex = Math.floor(Math.random() * (max - min + 1)) + min
         }
         let target = cards[cardPositionIndex]
-        const thumbnail = target.querySelector('.yt-img-shadow')
+        const thumbnail = target.querySelector('.ytd-thumbnail > img')
         thumbnail.src = result.thumbnailProperties.thumbnail
 
         const title = target.querySelector('#video-title')
@@ -103,7 +103,7 @@ function findCard() {
         }
 
         // Finally, set the channel's thumbnail in the preview
-        let avatar = target.querySelector('#avatar-link img')
+        let avatar = target.querySelector('#avatar-link .yt-img-shadow')
         if (avatar) {
             avatar.src = channelThumbnailValue
         }


### PR DESCRIPTION
Issue reported in https://twitter.com/BastiUi/status/1590722247677079552.

> **Warning**
> This PR doesn't tackle the "Random position" use case

This PR only tackles the basic use case when the user sets a channel image, channel name, video thumbnail and video title.

TBH I don't know all the details of how this extension works but that seems to fix the issue.

Basically, as mentioned by @bdebon in the Twitter thread, I've just modified the selectors.