### PR TITLE
Add Firefox extension ID in manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,10 @@
     "32": "/images/logo32.png",
     "48": "/images/logo48.png",
     "128": "/images/logo128.png"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{b98170d1-1cdd-45b2-bd5d-a7ee387d964a}"
+    }
   }
 }


### PR DESCRIPTION
The [Firefox addon](https://addons.mozilla.org/en-CA/firefox/addon/prevyou/) got a review recently that it's not working anymore.

<img width="805" alt="image" src="https://github.com/bdebon/youtube-thumbnail-tester-chrome-extension/assets/3929133/e7d6054b-efc2-4257-819c-46ba916b71b1">

I realize it was still outdated version 1.3 that indeed didn't work with the current YouTube DOM structure. Updating to 1.5 fixes it, so I just submitted 1.5 to the Firefox store!

But because it now uses manifest v3, Firefox requires the extension ID to be embedded in a special field in the manifest, so this PR keeps track of that.